### PR TITLE
Fixed sample config

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ In your `~/.hyperterm.js`, you can configure settings for `hyperclean`.
 modules.exports = {
   config: {
     // other config...
-    hyperClean: {
+    hyperclean: {
       hideTabs: true, // default: false
       hideFirstTabBorder: true, // default: false
     },


### PR DESCRIPTION
The sample config listed the key as 'hyperClean'. The screenshot further below in the readme shows the correct value of 'hyperclean'
